### PR TITLE
adds filename option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Speed up download of a single file with multiple HTTP GET connections running in
 
 MultipartDownload is an `EventEmitter`.
 
-### start(url, numOfConnections[, saveDirectory])
+### start(url, numOfConnections[, saveDirectory, filename])
 - `url` &lt;string&gt; Url of file to be downloaded
 - `numOfConnections` &lt;number&gt; Number of HTTP GET connections to use for performing the download
 - `saveDirectory` &lt;string&gt; Directory to save the downloaded file (Optional)
+- `filename` &lt;string&gt; Filename to save the downloaded file to (Optional)
 
 Starts the download operation from the `url`.
 

--- a/src/models/multipart-download.ts
+++ b/src/models/multipart-download.ts
@@ -11,13 +11,13 @@ import PartialDownload, {PartialDownloadRange} from '../models/partial-download'
 import PartialRequestQuery, {PartialRequestMetadata} from '../models/partial-request-query';
 
 export interface MultipartOperation {
-    start(url: string, numOfConnections: number, saveDirectory?: string): MultipartOperation;
+    start(url: string, numOfConnections: number, saveDirectory?: string, filename?: string): MultipartOperation;
 }
 
 export default class MultipartDownload extends events.EventEmitter implements MultipartOperation {
 
-    public start(url: string, numOfConnections: number, saveDirectory?: string): MultipartDownload {
-        const validationError: Error = this.validateInputs(url, numOfConnections, saveDirectory);
+    public start(url: string, numOfConnections: number, saveDirectory?: string, filename?: string): MultipartDownload {
+        const validationError: Error = this.validateInputs(url, numOfConnections, saveDirectory, filename);
         if (validationError) {
             throw validationError;
         }
@@ -37,7 +37,7 @@ export default class MultipartDownload extends events.EventEmitter implements Mu
 
                 let filePath: string = null;
                 if (saveDirectory) {
-                    filePath = this.createFile(url, saveDirectory);
+                    filePath = this.createFile(url, saveDirectory, filename);
                 }
 
                 let writeStream: fs.WriteStream;
@@ -98,8 +98,8 @@ export default class MultipartDownload extends events.EventEmitter implements Mu
         return null;
     }
 
-    private createFile(url: string, directory: string): string {
-        const filename: string = UrlParser.getFilename(url);
+    private createFile(url: string, directory: string, filename?: string): string {
+        const filename: string = filename ? filename : UrlParser.getFilename(url);
         const filePath: string = PathFormatter.format(directory, filename);
 
         fs.createWriteStream(filePath).end();

--- a/src/models/multipart-download.ts
+++ b/src/models/multipart-download.ts
@@ -99,8 +99,8 @@ export default class MultipartDownload extends events.EventEmitter implements Mu
     }
 
     private createFile(url: string, directory: string, filename?: string): string {
-        const filename: string = filename ? filename : UrlParser.getFilename(url);
-        const filePath: string = PathFormatter.format(directory, filename);
+        const _filename: string = filename ? filename : UrlParser.getFilename(url);
+        const filePath: string = PathFormatter.format(directory, _filename);
 
         fs.createWriteStream(filePath).end();
 


### PR DESCRIPTION
In some cases the provided URL does not contain a valid filename or is simply to long for the filesystem to handle, resulting in an error. For this case I added an optional filename parameter.