### PR TITLE
Replace head with get for s3 signed urls

### DIFF
--- a/src/models/partial-request-query.ts
+++ b/src/models/partial-request-query.ts
@@ -9,11 +9,9 @@ export class PartialRequestQuery {
     public getMetadata(url: string, headers?: request.Headers): Promise<PartialRequestMetadata> {
 
         return new Promise<PartialRequestMetadata>((resolve, reject) => {
-            const options: request.CoreOptions = {};
+            const options: request.CoreOptions = {'headers': {'Range': 'bytes=0-0'}};
 
-            options.headers = headers || null;
-
-            request.head(url, options, (err, res, body) => {
+            request.get(url, options, (err, res, body) => {
                 if (err) {
                     reject(err);
                 }


### PR DESCRIPTION
When a link is signed using amazon s3, the signature is made for a given request method HEAD, GET etc. 
We can sign both links or we can use a 0 size range with GET to make less requests to s3 and use the same signed link to get the required headers. 

This is a fix for that problem. 