### PR TITLE
feat: watch script for building

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "scripts": {
-    "build": "rm -rfv ./dist && tsc",
+    "build": "tsc",
+    "watch": "tsc --watch",
     "lint:dry": "tslint -c tslint.json src/**/*.ts",
     "lint:fix": "tslint -c tslint.json --fix src/**/*.ts",
     "test": "nyc mocha --reporter spec ./dist/test"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     },
     "exclude": [
         ".vscode",
-        "node_modules"
+        "node_modules",
+        "dist"
     ]
 }


### PR DESCRIPTION
fix: exclude dist directory in tsconfig.json
feat: watch script for building

since `rm -rf` is not available on all OSes, and since it is also not needed if you exclude `dist` directory in `tsconfig.json`, I have removed it and excluded the `dist` directory.

This also lets us use the `tsc --watch` command for fast development.